### PR TITLE
refactor/module-path: change module path to reflect the correct github repo url

### DIFF
--- a/backend/cmd/backend/in_memory_device_store.go
+++ b/backend/cmd/backend/in_memory_device_store.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"github.com/Prypiatos/energy-e3-app/backend/internal/models"
-	"github.com/Prypiatos/energy-e3-app/backend/internal/routes"
+	"github.com/Prypiatos/ems-app/backend/internal/models"
+	"github.com/Prypiatos/ems-app/backend/internal/routes"
 )
 
 func NewInMemoryDeviceStore() *InMemoryDeviceStore {

--- a/backend/cmd/backend/main.go
+++ b/backend/cmd/backend/main.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/Prypiatos/energy-e3-app/backend/internal/models"
-	"github.com/Prypiatos/energy-e3-app/backend/internal/routes"
+	"github.com/Prypiatos/ems-app/backend/internal/models"
+	"github.com/Prypiatos/ems-app/backend/internal/routes"
 )
 
 func main() {

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,3 +1,3 @@
-module github.com/Prypiatos/energy-e3-app/backend
+module github.com/Prypiatos/ems-app/backend
 
 go 1.26.1

--- a/backend/internal/routes/routes.go
+++ b/backend/internal/routes/routes.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/Prypiatos/energy-e3-app/backend/internal/models"
+	"github.com/Prypiatos/ems-app/backend/internal/models"
 )
 
 const (

--- a/backend/tests/routes_test.go
+++ b/backend/tests/routes_test.go
@@ -8,8 +8,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/Prypiatos/energy-e3-app/backend/internal/models"
-	"github.com/Prypiatos/energy-e3-app/backend/internal/routes"
+	"github.com/Prypiatos/ems-app/backend/internal/models"
+	"github.com/Prypiatos/ems-app/backend/internal/routes"
 )
 
 const jsonContentType = "application/json"


### PR DESCRIPTION
previous go module url was github.com/Prypiatos/energy-e3-app/backend which was not the correct url of the repository. changed it to github.com/Prypiatos/ems-app/backend