### PR TITLE
feat/12 initialise go kafka consumer service skeleton

### DIFF
--- a/backend/cmd/backend/main.go
+++ b/backend/cmd/backend/main.go
@@ -1,16 +1,55 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
+	"log/slog"
 	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
 
+	"github.com/Prypiatos/ems-app/backend/internal/kafka"
 	"github.com/Prypiatos/ems-app/backend/internal/routes"
 	"github.com/Prypiatos/ems-app/backend/internal/types"
 	"github.com/Prypiatos/shared-models/models"
 )
 
 func main() {
+
+	// --- slog setup ---
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	slog.SetDefault(logger)
+
+	// --- context with SIGTERM handling ---
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		ch := make(chan os.Signal, 1)
+		signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
+		<-ch
+		slog.Info("signal received, shutting down")
+		cancel()
+	}()
+
+	// --- Kafka consumers ---
+	consumers := []struct {
+		topic   string
+		groupID string
+	}{
+		{"energy.readings", "energy-readings"},
+		{"energy.anomalies", "energy-anomalies"},
+		{"energy.forecasts", "energy-forecasts"},
+	}
+
+	for _, cfg := range consumers {
+		c, err := kafka.NewConsumer(cfg.topic, cfg.groupID)
+		if err != nil {
+			log.Fatalf("failed to create consumer: %v", err)
+		}
+		go kafka.Consume(ctx, c)
+	}
 
 	// Seed in-memory node metadata for local development.
 	db := map[string]models.Node{
@@ -38,6 +77,24 @@ func main() {
 	port := 8080
 	addr := fmt.Sprintf(":%d", port)
 
-	log.Printf("Starting server on %s\n", addr)
-	log.Fatal(http.ListenAndServe(addr, server))
+	// --- HTTP server with graceful shutdown ---
+	httpServer := &http.Server{
+		Addr:    addr,
+		Handler: server,
+	}
+
+	go func() {
+		slog.Info("starting server", "addr", addr)
+		if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatalf("server error: %v", err)
+		}
+	}()
+
+	<-ctx.Done()
+
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer shutdownCancel()
+
+	slog.Info("shutting down http server")
+	_ = httpServer.Shutdown(shutdownCtx)
 }

--- a/backend/cmd/backend/main.go
+++ b/backend/cmd/backend/main.go
@@ -24,7 +24,7 @@ func main() {
 	slog.SetDefault(logger)
 
 	// --- context with SIGTERM handling ---
-	ctx := tools.WithSignalCancel()
+	ctx, cancel := tools.WithSignalCancel()
 
 	// --- Kafka consumers ---
 	consumers := []struct {

--- a/backend/cmd/backend/main.go
+++ b/backend/cmd/backend/main.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/Prypiatos/ems-app/backend/internal/kafka"
@@ -35,12 +36,14 @@ func main() {
 		{"energy.forecasts", "energy-forecasts"},
 	}
 
+	var wg sync.WaitGroup
+
 	for _, cfg := range consumers {
 		c, err := kafka.NewConsumer(cfg.topic, cfg.groupID)
 		if err != nil {
 			log.Fatalf("failed to create consumer: %v", err)
 		}
-		go kafka.Consume(ctx, c)
+		wg.Go(func() { kafka.Consume(ctx, c) })
 	}
 
 	// Seed in-memory node metadata for local development.
@@ -89,4 +92,7 @@ func main() {
 
 	slog.Info("shutting down http server")
 	_ = httpServer.Shutdown(shutdownCtx)
+	wg.Wait()
+	
+	slog.Info("shutdown complete")
 }

--- a/backend/cmd/backend/main.go
+++ b/backend/cmd/backend/main.go
@@ -7,12 +7,11 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
-	"os/signal"
-	"syscall"
 	"time"
 
 	"github.com/Prypiatos/ems-app/backend/internal/kafka"
 	"github.com/Prypiatos/ems-app/backend/internal/routes"
+	"github.com/Prypiatos/ems-app/backend/internal/tools"
 	"github.com/Prypiatos/ems-app/backend/internal/types"
 	"github.com/Prypiatos/shared-models/models"
 )
@@ -24,14 +23,7 @@ func main() {
 	slog.SetDefault(logger)
 
 	// --- context with SIGTERM handling ---
-	ctx, cancel := context.WithCancel(context.Background())
-	go func() {
-		ch := make(chan os.Signal, 1)
-		signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
-		<-ch
-		slog.Info("signal received, shutting down")
-		cancel()
-	}()
+	ctx := tools.WithSignalCancel()
 
 	// --- Kafka consumers ---
 	consumers := []struct {

--- a/backend/cmd/backend/main.go
+++ b/backend/cmd/backend/main.go
@@ -102,7 +102,11 @@ func main() {
 	defer shutdownCancel()
 
 	slog.Info("shutting down http server")
-	_ = httpServer.Shutdown(shutdownCtx)
+	if err := httpServer.Shutdown(shutdownCtx); err != nil {
+		slog.Error("server shutdown failed", "error", err)
+	} else {
+		slog.Info("server shutdown ok")
+	}
 	wg.Wait()
 
 	slog.Info("shutdown complete")

--- a/backend/cmd/backend/main.go
+++ b/backend/cmd/backend/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"log/slog"
@@ -78,14 +79,24 @@ func main() {
 		Handler: server,
 	}
 
+	serverErrChan := make(chan error, 1)
+
 	go func() {
 		slog.Info("starting server", "addr", addr)
-		if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			log.Fatalf("server error: %v", err)
+		if err := httpServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			select {
+			case serverErrChan <- err:
+			default:
+			}
+			cancel()
 		}
 	}()
 
-	<-ctx.Done()
+	select {
+	case <-ctx.Done():
+	case err := <-serverErrChan:
+		slog.Error("server error", "error", err)
+	}
 
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer shutdownCancel()
@@ -93,6 +104,6 @@ func main() {
 	slog.Info("shutting down http server")
 	_ = httpServer.Shutdown(shutdownCtx)
 	wg.Wait()
-	
+
 	slog.Info("shutdown complete")
 }

--- a/backend/cmd/backend/main.go
+++ b/backend/cmd/backend/main.go
@@ -44,7 +44,11 @@ func main() {
 		if err != nil {
 			log.Fatalf("failed to create consumer: %v", err)
 		}
-		wg.Go(func() { kafka.Consume(ctx, c) })
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			kafka.Consume(ctx, c)
+		}()
 	}
 
 	// Seed in-memory node metadata for local development.

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -4,6 +4,6 @@ go 1.26.1
 
 require (
 	github.com/Prypiatos/shared-models v1.0.0
-	github.com/confluentinc/confluent-kafka-go/v2 v2.14.0
+	github.com/confluentinc/confluent-kafka-go/v2 v2.14.1
 	github.com/gorilla/websocket v1.5.3
 )

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -52,8 +52,8 @@ github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/compose-spec/compose-go/v2 v2.1.3 h1:bD67uqLuL/XgkAK6ir3xZvNLFPxPScEi1KW7R5esrLE=
 github.com/compose-spec/compose-go/v2 v2.1.3/go.mod h1:lFN0DrMxIncJGYAXTfWuajfwj5haBJqrBkarHcnjJKc=
-github.com/confluentinc/confluent-kafka-go/v2 v2.14.0 h1:SCeCsGTKuWwnxTNltvh6fmj1lueTT5J2zvh9s2KYphg=
-github.com/confluentinc/confluent-kafka-go/v2 v2.14.0/go.mod h1:aR1aciwbULyLhKkv9eq88JhS4XmGOusEnHZx1R93XZI=
+github.com/confluentinc/confluent-kafka-go/v2 v2.14.1 h1:DOm/3yIL7L8GOEa7TFDht6MiNa/FiOeb8kNjHr28S/4=
+github.com/confluentinc/confluent-kafka-go/v2 v2.14.1/go.mod h1:aR1aciwbULyLhKkv9eq88JhS4XmGOusEnHZx1R93XZI=
 github.com/containerd/console v1.0.4 h1:F2g4+oChYvBTsASRTz8NP6iIAi97J3TtSAsLbIFn4ro=
 github.com/containerd/console v1.0.4/go.mod h1:YynlIjWYF8myEu6sdkwKIvGQq+cOckRm6So2avqoYAk=
 github.com/containerd/containerd v1.7.18 h1:jqjZTQNfXGoEaZdW1WwPU0RqSn1Bm2Ay/KJPUuO8nao=

--- a/backend/internal/kafka/consumer.go
+++ b/backend/internal/kafka/consumer.go
@@ -3,15 +3,13 @@ package kafka
 import (
 	"context"
 	"log/slog"
-	"os"
-	"os/signal"
-	"syscall"
 
+	"github.com/Prypiatos/ems-app/backend/internal/tools"
 	ckafka "github.com/confluentinc/confluent-kafka-go/v2/kafka"
 )
 
 func NewConsumer(topic, groupID string) (*ckafka.Consumer, error) {
-	broker := getenv("KAFKA_BROKER", "localhost:9092")
+	broker := tools.Getenv("KAFKA_BROKER", "localhost:9092")
 
 	c, err := ckafka.NewConsumer(&ckafka.ConfigMap{
 		"bootstrap.servers": broker,
@@ -65,25 +63,4 @@ func Consume(ctx context.Context, c *ckafka.Consumer) {
 			}
 		}
 	}
-}
-
-func WithSignalCancel() context.Context {
-	ctx, cancel := context.WithCancel(context.Background())
-
-	go func() {
-		ch := make(chan os.Signal, 1)
-		signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
-		<-ch
-		slog.Info("signal received, cancelling context")
-		cancel()
-	}()
-
-	return ctx
-}
-
-func getenv(k, def string) string {
-	if v := os.Getenv(k); v != "" {
-		return v
-	}
-	return def
 }

--- a/backend/internal/kafka/consumer.go
+++ b/backend/internal/kafka/consumer.go
@@ -7,7 +7,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	ckafka "github.com/confluentinc/confluent-kafka-go/kafka"
+	ckafka "github.com/confluentinc/confluent-kafka-go/v2/kafka"
 )
 
 func NewConsumer(topic, groupID string) (*ckafka.Consumer, error) {

--- a/backend/internal/kafka/consumer.go
+++ b/backend/internal/kafka/consumer.go
@@ -36,21 +36,32 @@ func NewConsumer(topic, groupID string) (*ckafka.Consumer, error) {
 }
 
 func Consume(ctx context.Context, c *ckafka.Consumer) {
+	defer func() {
+		if err := c.Close(); err != nil {
+			slog.Error("consumer Close error", "error", err)
+		}
+	}()
 	for {
 		select {
 		case <-ctx.Done():
 			slog.Info("consumer shutting down")
 			return
 		default:
-			msg, err := c.ReadMessage(-1)
-			if err == nil {
+
+			ev := c.Poll(100)
+			if ev == nil {
+				continue
+			}
+
+			switch e := ev.(type) {
+			case *ckafka.Message:
 				slog.Info("message consumed",
-					"topic", *msg.TopicPartition.Topic,
-					"partition", msg.TopicPartition.Partition,
-					"offset", msg.TopicPartition.Offset,
+					"topic", *e.TopicPartition.Topic,
+					"partition", e.TopicPartition.Partition,
+					"offset", e.TopicPartition.Offset,
 				)
-			} else {
-				slog.Error("consumer error", "error", err)
+			case ckafka.Error:
+				slog.Error("consumer error", "error", e)
 			}
 		}
 	}

--- a/backend/internal/kafka/consumer.go
+++ b/backend/internal/kafka/consumer.go
@@ -1,0 +1,78 @@
+package kafka
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+
+	ckafka "github.com/confluentinc/confluent-kafka-go/kafka"
+)
+
+func NewConsumer(topic, groupID string) (*ckafka.Consumer, error) {
+	broker := getenv("KAFKA_BROKER", "localhost:9092")
+
+	c, err := ckafka.NewConsumer(&ckafka.ConfigMap{
+		"bootstrap.servers": broker,
+		"group.id":          groupID,
+		"auto.offset.reset": "earliest",
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if err := c.SubscribeTopics([]string{topic}, nil); err != nil {
+		return nil, err
+	}
+
+	slog.Info("consumer created",
+		"topic", topic,
+		"group", groupID,
+		"broker", broker,
+	)
+
+	return c, nil
+}
+
+func Consume(ctx context.Context, c *ckafka.Consumer) {
+	for {
+		select {
+		case <-ctx.Done():
+			slog.Info("consumer shutting down")
+			return
+		default:
+			msg, err := c.ReadMessage(-1)
+			if err == nil {
+				slog.Info("message consumed",
+					"topic", *msg.TopicPartition.Topic,
+					"partition", msg.TopicPartition.Partition,
+					"offset", msg.TopicPartition.Offset,
+				)
+			} else {
+				slog.Error("consumer error", "error", err)
+			}
+		}
+	}
+}
+
+func WithSignalCancel() context.Context {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go func() {
+		ch := make(chan os.Signal, 1)
+		signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
+		<-ch
+		slog.Info("signal received, cancelling context")
+		cancel()
+	}()
+
+	return ctx
+}
+
+func getenv(k, def string) string {
+	if v := os.Getenv(k); v != "" {
+		return v
+	}
+	return def
+}

--- a/backend/internal/kafka/consumer.go
+++ b/backend/internal/kafka/consumer.go
@@ -21,6 +21,9 @@ func NewConsumer(topic, groupID string) (*ckafka.Consumer, error) {
 	}
 
 	if err := c.SubscribeTopics([]string{topic}, nil); err != nil {
+		if closeErr := c.Close(); closeErr != nil {
+			slog.Error("consumer Close error", "error", closeErr)
+		}
 		return nil, err
 	}
 

--- a/backend/internal/tools/tools.go
+++ b/backend/internal/tools/tools.go
@@ -8,7 +8,7 @@ import (
 	"syscall"
 )
 
-func WithSignalCancel() context.Context {
+func WithSignalCancel() (context.Context, context.CancelFunc) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	go func() {
@@ -19,7 +19,7 @@ func WithSignalCancel() context.Context {
 		cancel()
 	}()
 
-	return ctx
+	return ctx, cancel
 }
 
 func Getenv(k, def string) string {

--- a/backend/internal/tools/tools.go
+++ b/backend/internal/tools/tools.go
@@ -1,0 +1,30 @@
+package tools
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+func WithSignalCancel() context.Context {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go func() {
+		ch := make(chan os.Signal, 1)
+		signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
+		<-ch
+		slog.Info("signal received, cancelling context")
+		cancel()
+	}()
+
+	return ctx
+}
+
+func Getenv(k, def string) string {
+	if v := os.Getenv(k); v != "" {
+		return v
+	}
+	return def
+}

--- a/backend/internal/tools/tools.go
+++ b/backend/internal/tools/tools.go
@@ -14,9 +14,13 @@ func WithSignalCancel() (context.Context, context.CancelFunc) {
 	go func() {
 		ch := make(chan os.Signal, 1)
 		signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
-		<-ch
-		slog.Info("signal received, cancelling context")
-		cancel()
+		select {
+		case <-ch:
+			slog.Info("signal received, cancelling context")
+			cancel()
+		case <-ctx.Done():
+		}
+
 	}()
 
 	return ctx, cancel


### PR DESCRIPTION
- Adds a Kafka consumer service using confluent-kafka-go to process E1 and E2 events. 
- Implements a reusable consumer factory with configured consumer groups for `energy.readings`, `energy.anomalies`, and `energy.forecasts`. 
- Introduces a message consumption loop with context-based cancellation and structured logging via `slog`, including topic, partition, and offset. 
- Integrates consumers into main.go alongside the existing HTTP server and adds graceful shutdown handling on `SIGINT/SIGTERM`.