### PR TITLE
feat/check kafka broker health

### DIFF
--- a/backend/cmd/backend/main.go
+++ b/backend/cmd/backend/main.go
@@ -55,6 +55,15 @@ func main() {
 			return
 		}
 
+		if err := c.CheckHealth(); err != nil {
+			slog.Error("failed to reach broker", "error", err)
+
+			cancel()
+
+			wg.Wait()
+			return
+		}
+
 		consumers = append(consumers, c)
 
 		wg.Add(1)

--- a/backend/cmd/backend/main.go
+++ b/backend/cmd/backend/main.go
@@ -55,15 +55,6 @@ func main() {
 			return
 		}
 
-		if err := c.CheckHealth(); err != nil {
-			slog.Error("failed to reach broker", "error", err)
-
-			cancel()
-
-			wg.Wait()
-			return
-		}
-
 		consumers = append(consumers, c)
 
 		wg.Add(1)

--- a/backend/internal/kafka/confluent_consumer.go
+++ b/backend/internal/kafka/confluent_consumer.go
@@ -14,6 +14,10 @@ type confluentConsumer struct {
 func NewConsumer(topic, groupID string) (Consumer, error) {
 	broker := tools.Getenv("KAFKA_BROKER", "localhost:9092")
 
+	if err := CheckHealth(broker); err != nil {
+		return nil, err
+	}
+
 	c, err := ckafka.NewConsumer(&ckafka.ConfigMap{
 		"bootstrap.servers": broker,
 		"group.id":          groupID,
@@ -66,8 +70,7 @@ func (cc *confluentConsumer) Poll(timeoutMs int) any {
 	}
 }
 
-func (cc *confluentConsumer) CheckHealth() error {
-	broker := tools.Getenv("KAFKA_BROKER", "localhost:9092")
+func CheckHealth(broker string) error {
 	config := &ckafka.ConfigMap{
 		"bootstrap.servers": broker,
 		"socket.timeout.ms": 2000,
@@ -88,7 +91,7 @@ func (cc *confluentConsumer) CheckHealth() error {
 	}
 
 	if len(md.Brokers) == 0 {
-		slog.Error("No brokers available", "error", ErrNoBrokersAvailable)
+		return ErrNoBrokersAvailable
 	}
 
 	slog.Info("Kafka is reachable")

--- a/backend/internal/kafka/confluent_consumer.go
+++ b/backend/internal/kafka/confluent_consumer.go
@@ -65,3 +65,33 @@ func (cc *confluentConsumer) Poll(timeoutMs int) any {
 		return nil
 	}
 }
+
+func (cc *confluentConsumer) CheckHealth() error {
+	broker := tools.Getenv("KAFKA_BROKER", "localhost:9092")
+	config := &ckafka.ConfigMap{
+		"bootstrap.servers": broker,
+		"socket.timeout.ms": 2000,
+	}
+	admin, err := ckafka.NewAdminClient(config)
+
+	if err != nil {
+		slog.Error("Failed to create admin client", "error", err)
+		return err
+	}
+	defer admin.Close()
+
+	// Try to fetch cluster metadata
+	md, err := admin.GetMetadata(nil, false, 2000)
+	if err != nil {
+		slog.Error("Broker not reachable", "error", err)
+		return err
+	}
+
+	if len(md.Brokers) == 0 {
+		slog.Error("No brokers available", "error", ErrNoBrokersAvailable)
+	}
+
+	slog.Info("Kafka is reachable")
+
+	return nil
+}

--- a/backend/internal/kafka/consumer.go
+++ b/backend/internal/kafka/consumer.go
@@ -9,7 +9,6 @@ import (
 type Consumer interface {
 	Close() error
 	Poll(timeoutMs int) any
-	CheckHealth() error
 }
 
 var ErrNoBrokersAvailable = errors.New("no Kafka Brokers available")

--- a/backend/internal/kafka/consumer.go
+++ b/backend/internal/kafka/consumer.go
@@ -2,13 +2,17 @@ package kafka
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 )
 
 type Consumer interface {
 	Close() error
 	Poll(timeoutMs int) any
+	CheckHealth() error
 }
+
+var ErrNoBrokersAvailable = errors.New("no Kafka Brokers available")
 
 func Consume(ctx context.Context, c Consumer) {
 	for {


### PR DESCRIPTION
This pull request adds a health check for the Kafka broker connection before starting consumers, improving the reliability and observability of the service startup. The main changes include introducing a `CheckHealth` method to the consumer interface, implementing this method for the Confluent Kafka consumer, and updating the main application logic to perform the health check at startup.

**Kafka broker health checking:**

* Added a `CheckHealth` method to the `Consumer` interface in `consumer.go`, along with a new `ErrNoBrokersAvailable` error for clearer error reporting.
* Implemented the `CheckHealth` method in `confluent_consumer.go` to attempt connecting to the Kafka broker and fetch cluster metadata, logging errors if the broker is unreachable.

**Startup reliability improvements:**

* Updated `main.go` to call the new `CheckHealth` method before starting consumers, logging an error and aborting startup if the broker is not reachable.