### PR TITLE
feat/15 implement websocket server

### DIFF
--- a/backend/cmd/backend/main.go
+++ b/backend/cmd/backend/main.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
 	"sync"
@@ -107,11 +108,37 @@ func main() {
 	port := 8080
 	addr := fmt.Sprintf(":%d", port)
 
+	var hijackedConns sync.Map
+
 	// --- HTTP server with graceful shutdown ---
 	httpServer := &http.Server{
 		Addr:    addr,
 		Handler: topMux,
+		ConnState: func(conn net.Conn, state http.ConnState) {
+			switch state {
+			case http.StateHijacked:
+				hijackedConns.Store(conn, struct{}{})
+			case http.StateClosed:
+				hijackedConns.Delete(conn)
+			}
+		},
 	}
+
+	httpServer.RegisterOnShutdown(func() {
+		hijackedConns.Range(func(key, _ any) bool {
+			conn, ok := key.(net.Conn)
+			if !ok {
+				return true
+			}
+
+			if err := conn.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
+				slog.Warn("closing hijacked connection during shutdown failed", "error", err)
+			}
+			hijackedConns.Delete(conn)
+
+			return true
+		})
+	})
 
 	serverErrChan := make(chan error, 1)
 

--- a/backend/cmd/backend/main.go
+++ b/backend/cmd/backend/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Prypiatos/ems-app/backend/internal/routes"
 	"github.com/Prypiatos/ems-app/backend/internal/tools"
 	"github.com/Prypiatos/ems-app/backend/internal/types"
+	"github.com/Prypiatos/ems-app/backend/internal/ws"
 	"github.com/Prypiatos/shared-models/models"
 )
 
@@ -93,13 +94,23 @@ func main() {
 	deviceStore := &InMemoryDeviceStore{db: db, healthRecords: healthRecords, nodes: nodes}
 	server := routes.NewServer(deviceStore, nil)
 
+	// --- WebSocket hub ---
+	wsHub := ws.NewHub(slog.Default())
+
+	// Top-level mux: compose REST routes + WebSocket endpoint.
+	// This keeps the ws package fully decoupled from routes.Server.
+	topMux := http.NewServeMux()
+	topMux.Handle("/", server)
+	topMux.HandleFunc("GET /ws", ws.Handler(wsHub, slog.Default()))
+	topMux.HandleFunc("GET /socket.io/", ws.SocketIOHandler(wsHub, slog.Default()))
+
 	port := 8080
 	addr := fmt.Sprintf(":%d", port)
 
 	// --- HTTP server with graceful shutdown ---
 	httpServer := &http.Server{
 		Addr:    addr,
-		Handler: server,
+		Handler: topMux,
 	}
 
 	serverErrChan := make(chan error, 1)

--- a/backend/docs/contracts/socket-events.md
+++ b/backend/docs/contracts/socket-events.md
@@ -1,0 +1,303 @@
+# WebSocket Event Contracts
+
+> **Status**: Draft — API contracts not yet finalized.  
+> **Protocol**: WebSocket (RFC 6455) over `ws://` / `wss://`  
+> **Endpoint**: `GET /ws` (HTTP upgrade)  
+> **Library**: `gorilla/websocket`
+
+---
+
+## Connection
+
+| Property       | Value                                   |
+|----------------|-----------------------------------------|
+| Upgrade path   | `GET /ws`                               |
+| Socket.io path | `GET /socket.io/?EIO=4&transport=websocket` |
+| Subprotocol    | none (plain JSON text frames)           |
+| Ping interval  | ~54 s (server → client)                 |
+| Pong deadline  | 60 s                                    |
+| Max message    | 64 KB (inbound)                         |
+| Send buffer    | 256 messages per client                 |
+
+---
+
+## Wire Protocol
+
+All messages are JSON text frames. A single WebSocket connection multiplexes all topics.
+
+### Socket.io Compatibility
+
+The server exposes a minimal Engine.IO/Socket.IO websocket endpoint at:
+
+`/socket.io/?EIO=4&transport=websocket`
+
+Handshake flow:
+
+1. Server sends Engine.IO open packet (prefix `0`) with session metadata.
+2. Client sends Socket.IO connect packet `40`.
+3. Server sends Socket.IO connect ack packet `40{"sid":"..."}`.
+
+When using this endpoint:
+- Socket.IO event frames use prefix `42`.
+- Server event payloads are emitted as `42["event",{...}]`.
+- Control acks/errors are emitted as `42["ack",{...}]` or `42["error",{...}]`.
+
+### Client → Server
+
+#### `subscribe`
+
+Subscribe to a topic, optionally scoped to a room.
+
+```json
+{
+  "action": "subscribe",
+  "topic": "<topic_name>",
+  "room": "<room_key>"
+}
+```
+
+| Field    | Type     | Required | Description                                            |
+|----------|----------|----------|--------------------------------------------------------|
+| `action` | `string` | ✅        | Must be `"subscribe"`                                  |
+| `topic`  | `string` | ✅        | Logical event stream (see Topics below)                |
+| `room`   | `string` | ❌        | Scoping key, e.g. `"division:5"`. Omit for global.     |
+
+#### `unsubscribe`
+
+```json
+{
+  "action": "unsubscribe",
+  "topic": "<topic_name>",
+  "room": "<room_key>"
+}
+```
+
+Same fields as `subscribe`.
+
+#### `joinDivision` (Socket.io endpoint)
+
+Join a division room for a specific topic.
+
+```text
+42["joinDivision",{"topic":"readings","divisionId":"5"}]
+```
+
+Equivalent to:
+
+```json
+{
+  "action": "subscribe",
+  "topic": "readings",
+  "room": "division:5"
+}
+```
+
+#### `leaveDivision` (Socket.io endpoint)
+
+Leave a division room for a specific topic.
+
+```text
+42["leaveDivision",{"topic":"readings","divisionId":"5"}]
+```
+
+Equivalent to:
+
+```json
+{
+  "action": "unsubscribe",
+  "topic": "readings",
+  "room": "division:5"
+}
+```
+
+---
+
+### Server → Client
+
+#### Event Message
+
+Delivered when a producer publishes to a (topic, room) the client is subscribed to.
+
+```json
+{
+  "topic": "<topic_name>",
+  "room": "<room_key>",
+  "data": { ... }
+}
+```
+
+| Field  | Type     | Description                                         |
+|--------|----------|-----------------------------------------------------|
+| `topic`| `string` | The topic this message belongs to                   |
+| `room` | `string` | The room (empty string if global broadcast)         |
+| `data` | `object` | Opaque payload — structure depends on topic (below) |
+
+#### Acknowledgement
+
+Sent after a successful `subscribe` or `unsubscribe`.
+
+```json
+{
+  "type": "ack",
+  "action": "subscribe",
+  "topic": "readings",
+  "room": "division:5"
+}
+```
+
+#### Error
+
+Sent when the server cannot process a client message.
+
+```json
+{
+  "type": "error",
+  "message": "topic is required"
+}
+```
+
+Known error messages:
+- `"invalid JSON"` — message was not valid JSON
+- `"topic is required"` — topic field was empty
+- `"unknown action: <action>"` — action was not subscribe/unsubscribe
+
+---
+
+## Topics
+
+| Topic        | Kafka Source          | Description                    |
+|--------------|-----------------------|--------------------------------|
+| `readings`   | `energy.readings`     | Real-time energy reading updates |
+| `alerts`     | `energy.anomalies`    | Alert / anomaly events          |
+| `forecasts`  | `energy.forecasts`    | Energy forecast updates          |
+
+> **Note**: Topics are arbitrary strings. The WebSocket server does not validate topic names — any string is accepted. New topics can be added by publishing to them without code changes.
+
+---
+
+## Room Convention
+
+Rooms scope messages within a topic. The current convention:
+
+```
+division:{division_id}
+```
+
+Examples: `division:1`, `division:42`
+
+A client subscribed to `(topic="readings", room="division:5")` will only receive readings published to that exact (topic, room) pair. Omitting the room subscribes to global broadcasts for that topic.
+
+---
+
+## Payload Schemas (Per Topic)
+
+> ⚠️ **These are placeholder schemas.** Final payload structures will be defined once API contracts are agreed upon.
+
+### `readings`
+
+```json
+{
+  "node_id": "node_1",
+  "timestamp": 1713000000,
+  "voltage": 230.5,
+  "current": 12.3,
+  "power": 2835.15,
+  "energy_kwh": 1.42
+}
+```
+
+### `alerts`
+
+```json
+{
+  "alert_id": "alert_abc123",
+  "node_id": "node_2",
+  "severity": "high",
+  "type": "anomaly",
+  "message": "Current spike detected",
+  "timestamp": 1713000100
+}
+```
+
+### `forecasts`
+
+```json
+{
+  "division_id": "5",
+  "period_start": 1713000000,
+  "period_end": 1713003600,
+  "predicted_kwh": 42.5,
+  "confidence": 0.92
+}
+```
+
+---
+
+## Example Session
+
+```
+# 1. Client connects
+GET /ws HTTP/1.1
+Upgrade: websocket
+→ 101 Switching Protocols
+
+# 2. Client subscribes
+→ {"action":"subscribe","topic":"readings","room":"division:5"}
+← {"type":"ack","action":"subscribe","topic":"readings","room":"division:5"}
+
+# 3. Server pushes data
+← {"topic":"readings","room":"division:5","data":{"node_id":"node_1","voltage":230.5}}
+
+# 4. Client unsubscribes
+→ {"action":"unsubscribe","topic":"readings","room":"division:5"}
+← {"type":"ack","action":"unsubscribe","topic":"readings","room":"division:5"}
+
+# 5. Client disconnects
+→ close frame
+```
+
+### Socket.io Example Session
+
+```text
+# 1. Client connects
+GET /socket.io/?EIO=4&transport=websocket
+→ 101 Switching Protocols
+
+# 2. Server open packet
+← 0{"sid":"sio_...","upgrades":[],"pingInterval":25000,"pingTimeout":20000,"maxPayload":1000000}
+
+# 3. Client namespace connect
+→ 40
+← 40{"sid":"sio_..."}
+
+# 4. Join division room
+→ 42["joinDivision",{"topic":"readings","divisionId":"5"}]
+← 42["ack",{"type":"ack","action":"subscribe","topic":"readings","room":"division:5"}]
+
+# 5. Server pushes topic event
+← 42["event",{"topic":"readings","room":"division:5","data":{"node_id":"node_1","voltage":230.5}}]
+
+# 6. Leave room
+→ 42["leaveDivision",{"topic":"readings","divisionId":"5"}]
+← 42["ack",{"type":"ack","action":"unsubscribe","topic":"readings","room":"division:5"}]
+```
+
+---
+
+## Testing
+
+### With wscat
+
+```bash
+npx wscat -c ws://localhost:8080/ws
+> {"action":"subscribe","topic":"readings","room":"division:1"}
+< {"type":"ack","action":"subscribe","topic":"readings","room":"division:1"}
+```
+
+### With Postman
+
+1. Open Postman → New → WebSocket Request
+2. URL: `ws://localhost:8080/ws`
+3. Click **Connect**
+4. In the message field, paste: `{"action":"subscribe","topic":"readings","room":"division:1"}`
+5. Click **Send** — you should receive an ack

--- a/backend/docs/contracts/socket-events.md
+++ b/backend/docs/contracts/socket-events.md
@@ -9,15 +9,17 @@
 
 ## Connection
 
-| Property       | Value                                   |
-|----------------|-----------------------------------------|
-| Upgrade path   | `GET /ws`                               |
-| Socket.io path | `GET /socket.io/?EIO=4&transport=websocket` |
-| Subprotocol    | none (plain JSON text frames)           |
-| Ping interval  | ~54 s (server → client)                 |
-| Pong deadline  | 60 s                                    |
-| Max message    | 64 KB (inbound)                         |
-| Send buffer    | 256 messages per client                 |
+| Property                    | Value                                           |
+|-----------------------------|-------------------------------------------------|
+| Raw WS upgrade path         | `GET /ws`                                       |
+| Socket.IO path              | `GET /socket.io/?EIO=4&transport=websocket`     |
+| Raw WS subprotocol          | none (plain JSON text frames)                   |
+| Raw WS ping interval        | ~54 s (server → client)                         |
+| Raw WS pong deadline        | 60 s                                            |
+| Socket.IO ping interval     | 25 s (`pingInterval:25000` in Engine.IO open packet) |
+| Socket.IO ping timeout      | 20 s (`pingTimeout:20000` in Engine.IO open packet)  |
+| Max message                 | 64 KB (inbound)                                 |
+| Send buffer                 | 256 messages per client                         |
 
 ---
 
@@ -31,9 +33,13 @@ The server exposes a minimal Engine.IO/Socket.IO websocket endpoint at:
 
 `/socket.io/?EIO=4&transport=websocket`
 
+Heartbeat behavior differs by endpoint:
+- Raw `GET /ws` connections use the websocket server heartbeat documented above (`~54 s` ping interval, `60 s` pong deadline).
+- `GET /socket.io/?EIO=4&transport=websocket` connections use Engine.IO heartbeat values advertised in the open packet: `pingInterval:25000` and `pingTimeout:20000`.
+
 Handshake flow:
 
-1. Server sends Engine.IO open packet (prefix `0`) with session metadata.
+1. Server sends Engine.IO open packet (prefix `0`) with session metadata, including `pingInterval` and `pingTimeout`.
 2. Client sends Socket.IO connect packet `40`.
 3. Server sends Socket.IO connect ack packet `40{"sid":"..."}`.
 

--- a/backend/docs/contracts/socket-events.md
+++ b/backend/docs/contracts/socket-events.md
@@ -25,7 +25,7 @@
 
 ## Wire Protocol
 
-All messages are JSON text frames. A single WebSocket connection multiplexes all topics.
+Messages on `GET /ws` are plain JSON text frames, and a single raw WebSocket connection multiplexes all topics. The Socket.IO-compatible endpoint at `/socket.io/?EIO=4&transport=websocket` uses Engine.IO/Socket.IO framed text messages instead (for example `0{...}`, `40`, and `42["event",{...}]`).
 
 ### Socket.io Compatibility
 

--- a/backend/internal/bridge/kafka_ws.go
+++ b/backend/internal/bridge/kafka_ws.go
@@ -1,0 +1,40 @@
+// Package bridge provides thin adapters that connect infrastructure (Kafka, etc.)
+// to the WebSocket hub. It exists to keep the ws package free of domain knowledge.
+package bridge
+
+import (
+	"encoding/json"
+	"log/slog"
+
+	"github.com/Prypiatos/ems-app/backend/internal/ws"
+)
+
+// TopicMapping maps Kafka topic names to WebSocket topic names.
+// Extend this map when new Kafka topics are added.
+var TopicMapping = map[string]string{
+	"energy.readings":  "readings",
+	"energy.anomalies": "alerts",
+	"energy.forecasts": "forecasts",
+}
+
+// ForwardToHub publishes a Kafka message to the appropriate WebSocket topic.
+//
+// Parameters:
+//   - hub: the WebSocket hub to publish to
+//   - kafkaTopic: the Kafka topic the message came from
+//   - divisionID: extracted from the Kafka message key or payload; empty for global broadcast
+//   - payload: the raw JSON payload to relay (not deserialized)
+func ForwardToHub(hub *ws.Hub, kafkaTopic string, divisionID string, payload []byte) {
+	wsTopic, ok := TopicMapping[kafkaTopic]
+	if !ok {
+		slog.Warn("unknown kafka topic, skipping ws forward", "kafka_topic", kafkaTopic)
+		return
+	}
+
+	room := ""
+	if divisionID != "" {
+		room = "division:" + divisionID
+	}
+
+	hub.Publish(wsTopic, room, json.RawMessage(payload))
+}

--- a/backend/internal/ws/client.go
+++ b/backend/internal/ws/client.go
@@ -125,6 +125,13 @@ func (c *Client) WritePump() {
 
 		case <-ticker.C:
 			c.conn.SetWriteDeadline(time.Now().Add(writeWait))
+			if c.protocol == "socketio" {
+				if err := c.conn.WriteMessage(websocket.TextMessage, []byte("2")); err != nil {
+					return
+				}
+				continue
+			}
+
 			if err := c.conn.WriteMessage(websocket.PingMessage, nil); err != nil {
 				return
 			}

--- a/backend/internal/ws/client.go
+++ b/backend/internal/ws/client.go
@@ -286,10 +286,13 @@ func (c *Client) encodeControl(ctrl ControlMessage) ([]byte, error) {
 	return json.Marshal(ctrl)
 }
 
-func (c *Client) sendRaw(data []byte) {
+func (c *Client) sendRaw(data []byte) bool {
 	select {
 	case c.Send <- data:
+		return true
 	default:
+		slog.Warn("dropping outbound websocket message: send buffer full")
+		return false
 	}
 }
 
@@ -345,5 +348,12 @@ func (c *Client) sendControl(ctrl ControlMessage) {
 	if err != nil {
 		return
 	}
-	c.sendRaw(data)
+	if !c.sendRaw(data) {
+		slog.Warn("failed to deliver websocket control message: send buffer full",
+			"type", ctrl.Type,
+			"action", ctrl.Action,
+			"topic", ctrl.Topic,
+			"room", ctrl.Room,
+		)
+	}
 }

--- a/backend/internal/ws/client.go
+++ b/backend/internal/ws/client.go
@@ -1,0 +1,342 @@
+package ws
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+const (
+	// writeWait is the time allowed to write a message to the peer.
+	writeWait = 10 * time.Second
+
+	// pongWait is the time allowed to read the next pong message from the peer.
+	pongWait = 60 * time.Second
+
+	// pingPeriod is how often we send pings. Must be less than pongWait.
+	pingPeriod = (pongWait * 9) / 10
+
+	// maxMessageSize is the maximum inbound message size (64 KB).
+	maxMessageSize = 64 * 1024
+
+	// sendBufferSize is the capacity of the per-client outbound channel.
+	sendBufferSize = 256
+)
+
+// Client represents a single WebSocket connection.
+type Client struct {
+	ID          string
+	RemoteAddr  string
+	hub         *Hub
+	conn        *websocket.Conn
+	Send        chan []byte
+	logger      *slog.Logger
+	protocol    string
+	socketIOSID string
+}
+
+// NewClient creates a new Client bound to a hub and a WebSocket connection.
+func NewClient(id string, hub *Hub, conn *websocket.Conn, logger *slog.Logger) *Client {
+	return &Client{
+		ID:         id,
+		RemoteAddr: conn.RemoteAddr().String(),
+		hub:        hub,
+		conn:       conn,
+		Send:       make(chan []byte, sendBufferSize),
+		logger:     logger,
+		protocol:   "raw",
+	}
+}
+
+// NewSocketIOClient creates a client that speaks Engine.IO + Socket.IO frames.
+func NewSocketIOClient(id string, sid string, hub *Hub, conn *websocket.Conn, logger *slog.Logger) *Client {
+	c := NewClient(id, hub, conn, logger)
+	c.protocol = "socketio"
+	c.socketIOSID = sid
+	return c
+}
+
+// ReadPump reads inbound messages from the WebSocket and dispatches them.
+// It must be run in its own goroutine. When ReadPump returns, it unregisters
+// the client from the hub and closes the connection.
+func (c *Client) ReadPump() {
+	defer func() {
+		c.hub.Unregister(c)
+		c.conn.Close()
+	}()
+
+	c.conn.SetReadLimit(maxMessageSize)
+	c.conn.SetReadDeadline(time.Now().Add(pongWait))
+	c.conn.SetPongHandler(func(string) error {
+		c.conn.SetReadDeadline(time.Now().Add(pongWait))
+		return nil
+	})
+
+	for {
+		_, message, err := c.conn.ReadMessage()
+		if err != nil {
+			if websocket.IsUnexpectedCloseError(err,
+				websocket.CloseGoingAway,
+				websocket.CloseNormalClosure,
+			) {
+				c.logger.Error("unexpected websocket close",
+					"client_id", c.ID,
+					"error", err,
+				)
+			}
+			return
+		}
+
+		if c.protocol == "socketio" {
+			c.handleSocketIOMessage(message)
+			continue
+		}
+
+		c.handleMessage(message)
+	}
+}
+
+// WritePump pumps messages from the Send channel to the WebSocket connection.
+// It also sends periodic pings. Must be run in its own goroutine.
+func (c *Client) WritePump() {
+	ticker := time.NewTicker(pingPeriod)
+	defer func() {
+		ticker.Stop()
+		c.conn.Close()
+	}()
+
+	for {
+		select {
+		case msg, ok := <-c.Send:
+			c.conn.SetWriteDeadline(time.Now().Add(writeWait))
+			if !ok {
+				// Hub closed the channel (client unregistered).
+				c.conn.WriteMessage(websocket.CloseMessage, []byte{})
+				return
+			}
+
+			if err := c.conn.WriteMessage(websocket.TextMessage, msg); err != nil {
+				return
+			}
+
+		case <-ticker.C:
+			c.conn.SetWriteDeadline(time.Now().Add(writeWait))
+			if err := c.conn.WriteMessage(websocket.PingMessage, nil); err != nil {
+				return
+			}
+		}
+	}
+}
+
+// handleSocketIOMessage parses Engine.IO/Socket.IO frames and maps them to hub actions.
+func (c *Client) handleSocketIOMessage(raw []byte) {
+	frame := string(raw)
+
+	switch {
+	case frame == "2":
+		// Engine.IO ping -> pong.
+		c.sendRaw([]byte("3"))
+		return
+
+	case frame == "3":
+		// Engine.IO pong from client (noop).
+		return
+
+	case strings.HasPrefix(frame, "40"):
+		// Namespace connect ack for default namespace.
+		c.sendRaw([]byte(fmt.Sprintf(`40{"sid":"%s"}`, c.socketIOSID)))
+		return
+
+	case strings.HasPrefix(frame, "42"):
+		inbound, ctrlErr := parseSocketIOInbound(frame)
+		if ctrlErr != nil {
+			c.sendControl(*ctrlErr)
+			return
+		}
+
+		switch inbound.Action {
+		case "subscribe":
+			c.hub.Subscribe(c, inbound.Topic, inbound.Room)
+			c.sendControl(ControlMessage{
+				Type:   "ack",
+				Action: "subscribe",
+				Topic:  inbound.Topic,
+				Room:   inbound.Room,
+			})
+		case "unsubscribe":
+			c.hub.Unsubscribe(c, inbound.Topic, inbound.Room)
+			c.sendControl(ControlMessage{
+				Type:   "ack",
+				Action: "unsubscribe",
+				Topic:  inbound.Topic,
+				Room:   inbound.Room,
+			})
+		default:
+			c.sendControl(ControlMessage{Type: "error", Message: "unknown action: " + inbound.Action})
+		}
+		return
+
+	default:
+		c.sendControl(ControlMessage{
+			Type:    "error",
+			Message: "unsupported socket.io frame",
+		})
+	}
+}
+
+type socketIODivisionPayload struct {
+	Topic      string `json:"topic"`
+	DivisionID string `json:"divisionId"`
+}
+
+func parseSocketIOInbound(frame string) (InboundMessage, *ControlMessage) {
+	var packet []json.RawMessage
+	if err := json.Unmarshal([]byte(frame[2:]), &packet); err != nil {
+		return InboundMessage{}, &ControlMessage{Type: "error", Message: "invalid socket.io event packet"}
+	}
+
+	if len(packet) < 2 {
+		return InboundMessage{}, &ControlMessage{Type: "error", Message: "socket.io event payload is required"}
+	}
+
+	var eventName string
+	if err := json.Unmarshal(packet[0], &eventName); err != nil {
+		return InboundMessage{}, &ControlMessage{Type: "error", Message: "invalid socket.io event name"}
+	}
+
+	switch eventName {
+	case "subscribe", "unsubscribe":
+		var payload InboundMessage
+		if err := json.Unmarshal(packet[1], &payload); err != nil {
+			return InboundMessage{}, &ControlMessage{Type: "error", Message: "invalid subscribe payload"}
+		}
+		if payload.Topic == "" {
+			return InboundMessage{}, &ControlMessage{Type: "error", Message: "topic is required"}
+		}
+		payload.Action = eventName
+		return payload, nil
+
+	case "joinDivision":
+		var payload socketIODivisionPayload
+		if err := json.Unmarshal(packet[1], &payload); err != nil {
+			return InboundMessage{}, &ControlMessage{Type: "error", Message: "invalid joinDivision payload"}
+		}
+		if payload.Topic == "" {
+			return InboundMessage{}, &ControlMessage{Type: "error", Message: "topic is required"}
+		}
+		if payload.DivisionID == "" {
+			return InboundMessage{}, &ControlMessage{Type: "error", Message: "divisionId is required"}
+		}
+		return InboundMessage{Action: "subscribe", Topic: payload.Topic, Room: "division:" + payload.DivisionID}, nil
+
+	case "leaveDivision":
+		var payload socketIODivisionPayload
+		if err := json.Unmarshal(packet[1], &payload); err != nil {
+			return InboundMessage{}, &ControlMessage{Type: "error", Message: "invalid leaveDivision payload"}
+		}
+		if payload.Topic == "" {
+			return InboundMessage{}, &ControlMessage{Type: "error", Message: "topic is required"}
+		}
+		if payload.DivisionID == "" {
+			return InboundMessage{}, &ControlMessage{Type: "error", Message: "divisionId is required"}
+		}
+		return InboundMessage{Action: "unsubscribe", Topic: payload.Topic, Room: "division:" + payload.DivisionID}, nil
+
+	default:
+		return InboundMessage{}, &ControlMessage{Type: "error", Message: "unknown socket.io event: " + eventName}
+	}
+}
+
+func (c *Client) encodeOutbound(msg OutboundMessage) ([]byte, error) {
+	if c.protocol == "socketio" {
+		payload, err := json.Marshal(msg)
+		if err != nil {
+			return nil, err
+		}
+		return []byte(`42["event",` + string(payload) + `]`), nil
+	}
+
+	return json.Marshal(msg)
+}
+
+func (c *Client) encodeControl(ctrl ControlMessage) ([]byte, error) {
+	if c.protocol == "socketio" {
+		payload, err := json.Marshal(ctrl)
+		if err != nil {
+			return nil, err
+		}
+		eventName := ctrl.Type
+		if eventName == "" {
+			eventName = "message"
+		}
+		return []byte(`42["` + eventName + `",` + string(payload) + `]`), nil
+	}
+
+	return json.Marshal(ctrl)
+}
+
+func (c *Client) sendRaw(data []byte) {
+	select {
+	case c.Send <- data:
+	default:
+	}
+}
+
+// handleMessage parses an inbound JSON message and dispatches subscribe/unsubscribe.
+func (c *Client) handleMessage(raw []byte) {
+	var msg InboundMessage
+	if err := json.Unmarshal(raw, &msg); err != nil {
+		c.sendControl(ControlMessage{
+			Type:    "error",
+			Message: "invalid JSON",
+		})
+		return
+	}
+
+	if msg.Topic == "" {
+		c.sendControl(ControlMessage{
+			Type:    "error",
+			Message: "topic is required",
+		})
+		return
+	}
+
+	switch msg.Action {
+	case "subscribe":
+		c.hub.Subscribe(c, msg.Topic, msg.Room)
+		c.sendControl(ControlMessage{
+			Type:   "ack",
+			Action: "subscribe",
+			Topic:  msg.Topic,
+			Room:   msg.Room,
+		})
+
+	case "unsubscribe":
+		c.hub.Unsubscribe(c, msg.Topic, msg.Room)
+		c.sendControl(ControlMessage{
+			Type:   "ack",
+			Action: "unsubscribe",
+			Topic:  msg.Topic,
+			Room:   msg.Room,
+		})
+
+	default:
+		c.sendControl(ControlMessage{
+			Type:    "error",
+			Message: "unknown action: " + msg.Action,
+		})
+	}
+}
+
+// sendControl marshals and enqueues a control message to the client.
+func (c *Client) sendControl(ctrl ControlMessage) {
+	data, err := c.encodeControl(ctrl)
+	if err != nil {
+		return
+	}
+	c.sendRaw(data)
+}

--- a/backend/internal/ws/handler.go
+++ b/backend/internal/ws/handler.go
@@ -13,6 +13,13 @@ import (
 // clientCounter generates unique client IDs without an external dependency.
 var clientCounter atomic.Uint64
 
+const (
+	// These Engine.IO values must stay aligned with the actual heartbeat cadence
+	// used by Client.WritePump for websocket ping frames.
+	socketIOPingIntervalMillis = 54000
+	socketIOPingTimeoutMillis  = 60000
+)
+
 var upgrader = websocket.Upgrader{
 	ReadBufferSize:  1024,
 	WriteBufferSize: 1024,
@@ -68,7 +75,12 @@ func SocketIOHandler(hub *Hub, logger *slog.Logger) http.HandlerFunc {
 		}
 
 		sid := fmt.Sprintf("sio_%d", time.Now().UnixNano())
-		open := fmt.Sprintf(`0{"sid":"%s","upgrades":[],"pingInterval":25000,"pingTimeout":20000,"maxPayload":1000000}`, sid)
+		open := fmt.Sprintf(
+			`0{"sid":"%s","upgrades":[],"pingInterval":%d,"pingTimeout":%d,"maxPayload":1000000}`,
+			sid,
+			socketIOPingIntervalMillis,
+			socketIOPingTimeoutMillis,
+		)
 		if err := conn.WriteMessage(websocket.TextMessage, []byte(open)); err != nil {
 			logger.Error("failed to write socket.io open packet", "error", err)
 			conn.Close()

--- a/backend/internal/ws/handler.go
+++ b/backend/internal/ws/handler.go
@@ -1,0 +1,85 @@
+package ws
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+	"sync/atomic"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// clientCounter generates unique client IDs without an external dependency.
+var clientCounter atomic.Uint64
+
+var upgrader = websocket.Upgrader{
+	ReadBufferSize:  1024,
+	WriteBufferSize: 1024,
+	// TODO: restrict CheckOrigin in production.
+	CheckOrigin: func(r *http.Request) bool { return true },
+}
+
+// Handler returns an http.HandlerFunc that upgrades HTTP requests to WebSocket
+// connections and registers them with the given Hub.
+//
+// Mount it on any path, e.g.:
+//
+//	mux.HandleFunc("GET /ws", ws.Handler(hub, logger))
+func Handler(hub *Hub, logger *slog.Logger) http.HandlerFunc {
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			logger.Error("websocket upgrade failed", "error", err)
+			return
+		}
+
+		clientID := fmt.Sprintf("client_%d", clientCounter.Add(1))
+		client := NewClient(clientID, hub, conn, logger)
+		hub.Register(client)
+
+		// Each client needs exactly two goroutines.
+		go client.WritePump()
+		go client.ReadPump()
+	}
+}
+
+// SocketIOHandler provides a minimal Socket.IO v4-compatible websocket endpoint.
+// It supports Engine.IO websocket transport and join/leave division events.
+func SocketIOHandler(hub *Hub, logger *slog.Logger) http.HandlerFunc {
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("transport") != "websocket" {
+			http.Error(w, "transport must be websocket", http.StatusBadRequest)
+			return
+		}
+
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			logger.Error("socket.io websocket upgrade failed", "error", err)
+			return
+		}
+
+		sid := fmt.Sprintf("sio_%d", time.Now().UnixNano())
+		open := fmt.Sprintf(`0{"sid":"%s","upgrades":[],"pingInterval":25000,"pingTimeout":20000,"maxPayload":1000000}`, sid)
+		if err := conn.WriteMessage(websocket.TextMessage, []byte(open)); err != nil {
+			logger.Error("failed to write socket.io open packet", "error", err)
+			conn.Close()
+			return
+		}
+
+		clientID := fmt.Sprintf("client_%d", clientCounter.Add(1))
+		client := NewSocketIOClient(clientID, sid, hub, conn, logger)
+		hub.Register(client)
+
+		go client.WritePump()
+		go client.ReadPump()
+	}
+}

--- a/backend/internal/ws/hub.go
+++ b/backend/internal/ws/hub.go
@@ -1,0 +1,162 @@
+package ws
+
+import (
+	"encoding/json"
+	"log/slog"
+	"sync"
+)
+
+// subscriptionKey identifies a unique (topic, room) pair.
+type subscriptionKey struct {
+	Topic string
+	Room  string
+}
+
+// Hub manages client connections, subscriptions, and message fan-out.
+// It is safe for concurrent use.
+type Hub struct {
+	mu          sync.RWMutex
+	clients     map[*Client]struct{}
+	subscribers map[subscriptionKey]map[*Client]struct{}
+	logger      *slog.Logger
+}
+
+// NewHub creates a new Hub. Pass a structured logger; if nil, slog.Default() is used.
+func NewHub(logger *slog.Logger) *Hub {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Hub{
+		clients:     make(map[*Client]struct{}),
+		subscribers: make(map[subscriptionKey]map[*Client]struct{}),
+		logger:      logger,
+	}
+}
+
+// Register adds a client to the hub. Called when a WebSocket connection is established.
+func (h *Hub) Register(c *Client) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.clients[c] = struct{}{}
+	h.logger.Info("client registered",
+		"client_id", c.ID,
+		"remote_addr", c.RemoteAddr,
+		"total_clients", len(h.clients),
+	)
+}
+
+// Unregister removes a client and all its subscriptions.
+// Called when the WebSocket connection is closed.
+func (h *Hub) Unregister(c *Client) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	for key, subs := range h.subscribers {
+		delete(subs, c)
+		if len(subs) == 0 {
+			delete(h.subscribers, key)
+		}
+	}
+
+	delete(h.clients, c)
+	close(c.Send)
+
+	h.logger.Info("client unregistered",
+		"client_id", c.ID,
+		"total_clients", len(h.clients),
+	)
+}
+
+// Subscribe adds a client to a (topic, room) channel.
+func (h *Hub) Subscribe(c *Client, topic, room string) {
+	key := subscriptionKey{Topic: topic, Room: room}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if h.subscribers[key] == nil {
+		h.subscribers[key] = make(map[*Client]struct{})
+	}
+	h.subscribers[key][c] = struct{}{}
+
+	h.logger.Info("client subscribed",
+		"client_id", c.ID,
+		"topic", topic,
+		"room", room,
+	)
+}
+
+// Unsubscribe removes a client from a (topic, room) channel.
+func (h *Hub) Unsubscribe(c *Client, topic, room string) {
+	key := subscriptionKey{Topic: topic, Room: room}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if subs, ok := h.subscribers[key]; ok {
+		delete(subs, c)
+		if len(subs) == 0 {
+			delete(h.subscribers, key)
+		}
+	}
+
+	h.logger.Info("client unsubscribed",
+		"client_id", c.ID,
+		"topic", topic,
+		"room", room,
+	)
+}
+
+// Publish sends a payload to all clients subscribed to (topic, room).
+// The data argument must be pre-serialized JSON. This is the method
+// external producers (e.g. a Kafka bridge) call.
+func (h *Hub) Publish(topic, room string, data json.RawMessage) {
+	msg := OutboundMessage{
+		Topic: topic,
+		Room:  room,
+		Data:  data,
+	}
+
+	key := subscriptionKey{Topic: topic, Room: room}
+
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	subs := h.subscribers[key]
+	for client := range subs {
+		payload, err := client.encodeOutbound(msg)
+		if err != nil {
+			h.logger.Error("failed to encode outbound message",
+				"error", err,
+				"client_id", client.ID,
+			)
+			continue
+		}
+
+		select {
+		case client.Send <- payload:
+		default:
+			// Client send buffer is full — drop this message (non-blocking).
+			h.logger.Warn("dropping message, client buffer full",
+				"client_id", client.ID,
+				"topic", topic,
+				"room", room,
+			)
+		}
+	}
+}
+
+// ClientCount returns the current number of connected clients.
+func (h *Hub) ClientCount() int {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return len(h.clients)
+}
+
+// SubscriberCount returns the number of clients subscribed to a (topic, room).
+func (h *Hub) SubscriberCount(topic, room string) int {
+	key := subscriptionKey{Topic: topic, Room: room}
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return len(h.subscribers[key])
+}

--- a/backend/internal/ws/protocol.go
+++ b/backend/internal/ws/protocol.go
@@ -1,0 +1,29 @@
+// Package ws provides a self-contained, topic-agnostic WebSocket pub/sub hub.
+// It has zero knowledge of domain models, Kafka, or API contracts.
+// Producers push pre-serialized []byte payloads; the hub relays them untouched.
+package ws
+
+import "encoding/json"
+
+// InboundMessage is what clients send to the server.
+type InboundMessage struct {
+	Action string `json:"action"`        // "subscribe" | "unsubscribe"
+	Topic  string `json:"topic"`         // logical event stream name
+	Room   string `json:"room,omitempty"` // scoping key, e.g. "division:5"; empty = global
+}
+
+// OutboundMessage is what the server pushes to clients.
+type OutboundMessage struct {
+	Topic string          `json:"topic"`
+	Room  string          `json:"room,omitempty"`
+	Data  json.RawMessage `json:"data"` // opaque payload — never deserialized by this package
+}
+
+// ControlMessage is a server→client acknowledgement or error.
+type ControlMessage struct {
+	Type    string `json:"type"`              // "ack" | "error"
+	Action  string `json:"action,omitempty"`  // echoed from the inbound action
+	Topic   string `json:"topic,omitempty"`
+	Room    string `json:"room,omitempty"`
+	Message string `json:"message,omitempty"` // human-readable detail
+}

--- a/backend/tests/hub_test.go
+++ b/backend/tests/hub_test.go
@@ -1,0 +1,393 @@
+package tests
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+
+	"github.com/Prypiatos/ems-app/backend/internal/ws"
+)
+
+// dial is a helper that upgrades to WebSocket against a test server.
+func dial(t *testing.T, s *httptest.Server) *websocket.Conn {
+	t.Helper()
+	wsURL := "ws" + strings.TrimPrefix(s.URL, "http") + "/ws"
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial failed: %v", err)
+	}
+	return conn
+}
+
+func dialSocketIO(t *testing.T, s *httptest.Server) *websocket.Conn {
+	t.Helper()
+	wsURL := "ws" + strings.TrimPrefix(s.URL, "http") + "/socket.io/?EIO=4&transport=websocket"
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("socket.io dial failed: %v", err)
+	}
+	return conn
+}
+
+func setupServer(t *testing.T) (*ws.Hub, *httptest.Server) {
+	t.Helper()
+	logger := slog.Default()
+	hub := ws.NewHub(logger)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /ws", ws.Handler(hub, logger))
+	mux.HandleFunc("GET /socket.io/", ws.SocketIOHandler(hub, logger))
+
+	s := httptest.NewServer(mux)
+	t.Cleanup(s.Close)
+	return hub, s
+}
+
+func readSocketIOFrame(t *testing.T, conn *websocket.Conn) string {
+	t.Helper()
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, data, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("socket.io frame read failed: %v", err)
+	}
+	return string(data)
+}
+
+func readSocketIOEvent[T any](t *testing.T, conn *websocket.Conn, expectedEvent string) T {
+	t.Helper()
+	frame := readSocketIOFrame(t, conn)
+	if !strings.HasPrefix(frame, "42") {
+		t.Fatalf("expected socket.io event frame 42, got: %s", frame)
+	}
+
+	var packet []json.RawMessage
+	if err := json.Unmarshal([]byte(frame[2:]), &packet); err != nil {
+		t.Fatalf("failed to parse socket.io packet: %v", err)
+	}
+	if len(packet) < 2 {
+		t.Fatalf("invalid socket.io packet: %s", frame)
+	}
+
+	var eventName string
+	if err := json.Unmarshal(packet[0], &eventName); err != nil {
+		t.Fatalf("failed to parse socket.io event name: %v", err)
+	}
+	if eventName != expectedEvent {
+		t.Fatalf("expected socket.io event %q, got %q", expectedEvent, eventName)
+	}
+
+	var payload T
+	if err := json.Unmarshal(packet[1], &payload); err != nil {
+		t.Fatalf("failed to decode socket.io payload: %v", err)
+	}
+	return payload
+}
+
+func readJSON[T any](t *testing.T, conn *websocket.Conn) T {
+	t.Helper()
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, data, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("read failed: %v", err)
+	}
+	var v T
+	if err := json.Unmarshal(data, &v); err != nil {
+		t.Fatalf("unmarshal failed: %v\nraw: %s", err, data)
+	}
+	return v
+}
+
+// ---------- Tests ----------
+
+func TestHandshakeSucceeds(t *testing.T) {
+	hub, s := setupServer(t)
+	conn := dial(t, s)
+	defer conn.Close()
+
+	// Give the hub a moment to process the registration.
+	time.Sleep(50 * time.Millisecond)
+
+	if got := hub.ClientCount(); got != 1 {
+		t.Errorf("expected 1 client, got %d", got)
+	}
+}
+
+func TestSocketIOHandshakeSucceeds(t *testing.T) {
+	hub, s := setupServer(t)
+	conn := dialSocketIO(t, s)
+	defer conn.Close()
+
+	open := readSocketIOFrame(t, conn)
+	if !strings.HasPrefix(open, "0{") {
+		t.Fatalf("expected Engine.IO open packet, got: %s", open)
+	}
+
+	if err := conn.WriteMessage(websocket.TextMessage, []byte("40")); err != nil {
+		t.Fatalf("failed to send socket.io connect packet: %v", err)
+	}
+
+	connectAck := readSocketIOFrame(t, conn)
+	if !strings.HasPrefix(connectAck, "40") {
+		t.Fatalf("expected Socket.IO connect ack packet, got: %s", connectAck)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	if got := hub.ClientCount(); got != 1 {
+		t.Errorf("expected 1 socket.io client, got %d", got)
+	}
+}
+
+func TestSocketIOJoinLeaveDivisionRoom(t *testing.T) {
+	hub, s := setupServer(t)
+	conn := dialSocketIO(t, s)
+	defer conn.Close()
+
+	_ = readSocketIOFrame(t, conn) // open packet
+	if err := conn.WriteMessage(websocket.TextMessage, []byte("40")); err != nil {
+		t.Fatalf("failed to connect socket.io namespace: %v", err)
+	}
+	_ = readSocketIOFrame(t, conn) // connect ack
+
+	join := `42["joinDivision",{"topic":"readings","divisionId":"7"}]`
+	if err := conn.WriteMessage(websocket.TextMessage, []byte(join)); err != nil {
+		t.Fatalf("failed to write joinDivision packet: %v", err)
+	}
+
+	ack := readSocketIOEvent[ws.ControlMessage](t, conn, "ack")
+	if ack.Action != "subscribe" || ack.Topic != "readings" || ack.Room != "division:7" {
+		t.Fatalf("unexpected join ack: %+v", ack)
+	}
+
+	hub.Publish("readings", "division:7", json.RawMessage(`{"kwh":12.5}`))
+	out := readSocketIOEvent[ws.OutboundMessage](t, conn, "event")
+	if out.Topic != "readings" || out.Room != "division:7" {
+		t.Fatalf("unexpected socket.io outbound event: %+v", out)
+	}
+
+	leave := `42["leaveDivision",{"topic":"readings","divisionId":"7"}]`
+	if err := conn.WriteMessage(websocket.TextMessage, []byte(leave)); err != nil {
+		t.Fatalf("failed to write leaveDivision packet: %v", err)
+	}
+
+	unsubAck := readSocketIOEvent[ws.ControlMessage](t, conn, "ack")
+	if unsubAck.Action != "unsubscribe" || unsubAck.Topic != "readings" || unsubAck.Room != "division:7" {
+		t.Fatalf("unexpected leave ack: %+v", unsubAck)
+	}
+
+	hub.Publish("readings", "division:7", json.RawMessage(`{"kwh":13.1}`))
+
+	conn.SetReadDeadline(time.Now().Add(200 * time.Millisecond))
+	_, _, err := conn.ReadMessage()
+	if err == nil {
+		t.Fatal("expected no event after leaveDivision")
+	}
+}
+
+func TestSubscribeAndReceiveMessage(t *testing.T) {
+	hub, s := setupServer(t)
+	conn := dial(t, s)
+	defer conn.Close()
+
+	// Subscribe to a topic + room.
+	sub := ws.InboundMessage{
+		Action: "subscribe",
+		Topic:  "readings",
+		Room:   "division:5",
+	}
+	if err := conn.WriteJSON(sub); err != nil {
+		t.Fatalf("write subscribe failed: %v", err)
+	}
+
+	// Read the ack.
+	ack := readJSON[ws.ControlMessage](t, conn)
+	if ack.Type != "ack" || ack.Action != "subscribe" || ack.Topic != "readings" || ack.Room != "division:5" {
+		t.Errorf("unexpected ack: %+v", ack)
+	}
+
+	// Wait for subscription to be processed.
+	time.Sleep(50 * time.Millisecond)
+
+	// Publish a message from the server side.
+	payload := json.RawMessage(`{"voltage":230.5,"current":12.3}`)
+	hub.Publish("readings", "division:5", payload)
+
+	// Read the outbound message.
+	out := readJSON[ws.OutboundMessage](t, conn)
+	if out.Topic != "readings" || out.Room != "division:5" {
+		t.Errorf("unexpected outbound message: %+v", out)
+	}
+
+	var data map[string]float64
+	if err := json.Unmarshal(out.Data, &data); err != nil {
+		t.Fatalf("unmarshal data failed: %v", err)
+	}
+	if data["voltage"] != 230.5 {
+		t.Errorf("expected voltage=230.5, got %v", data["voltage"])
+	}
+}
+
+func TestUnsubscribeStopsMessages(t *testing.T) {
+	hub, s := setupServer(t)
+	conn := dial(t, s)
+	defer conn.Close()
+
+	// Subscribe.
+	if err := conn.WriteJSON(ws.InboundMessage{Action: "subscribe", Topic: "alerts", Room: "division:1"}); err != nil {
+		t.Fatal(err)
+	}
+	_ = readJSON[ws.ControlMessage](t, conn) // consume ack
+
+	// Unsubscribe.
+	if err := conn.WriteJSON(ws.InboundMessage{Action: "unsubscribe", Topic: "alerts", Room: "division:1"}); err != nil {
+		t.Fatal(err)
+	}
+	unsubAck := readJSON[ws.ControlMessage](t, conn)
+	if unsubAck.Type != "ack" || unsubAck.Action != "unsubscribe" {
+		t.Errorf("unexpected unsub ack: %+v", unsubAck)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Publish — client should NOT receive this.
+	hub.Publish("alerts", "division:1", json.RawMessage(`{"severity":"high"}`))
+
+	// Try to read with a short deadline — should timeout.
+	conn.SetReadDeadline(time.Now().Add(200 * time.Millisecond))
+	_, _, err := conn.ReadMessage()
+	if err == nil {
+		t.Error("expected no message after unsubscribe, but got one")
+	}
+}
+
+func TestMultipleClientsReceiveSameMessage(t *testing.T) {
+	hub, s := setupServer(t)
+
+	conn1 := dial(t, s)
+	defer conn1.Close()
+	conn2 := dial(t, s)
+	defer conn2.Close()
+
+	// Both subscribe to the same topic+room.
+	sub := ws.InboundMessage{Action: "subscribe", Topic: "forecasts", Room: "division:3"}
+	conn1.WriteJSON(sub)
+	conn2.WriteJSON(sub)
+
+	_ = readJSON[ws.ControlMessage](t, conn1) // ack
+	_ = readJSON[ws.ControlMessage](t, conn2) // ack
+
+	time.Sleep(50 * time.Millisecond)
+
+	hub.Publish("forecasts", "division:3", json.RawMessage(`{"predicted_kwh":42}`))
+
+	out1 := readJSON[ws.OutboundMessage](t, conn1)
+	out2 := readJSON[ws.OutboundMessage](t, conn2)
+
+	if out1.Topic != "forecasts" || out2.Topic != "forecasts" {
+		t.Errorf("both clients should receive the forecast message")
+	}
+}
+
+func TestDifferentRoomsAreIsolated(t *testing.T) {
+	hub, s := setupServer(t)
+
+	conn1 := dial(t, s)
+	defer conn1.Close()
+	conn2 := dial(t, s)
+	defer conn2.Close()
+
+	// conn1 subscribes to division:1, conn2 to division:2.
+	conn1.WriteJSON(ws.InboundMessage{Action: "subscribe", Topic: "readings", Room: "division:1"})
+	conn2.WriteJSON(ws.InboundMessage{Action: "subscribe", Topic: "readings", Room: "division:2"})
+
+	_ = readJSON[ws.ControlMessage](t, conn1) // ack
+	_ = readJSON[ws.ControlMessage](t, conn2) // ack
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Publish to division:1 only.
+	hub.Publish("readings", "division:1", json.RawMessage(`{"node":"A"}`))
+
+	// conn1 should get it.
+	out := readJSON[ws.OutboundMessage](t, conn1)
+	if out.Room != "division:1" {
+		t.Errorf("expected room division:1, got %s", out.Room)
+	}
+
+	// conn2 should NOT get it.
+	conn2.SetReadDeadline(time.Now().Add(200 * time.Millisecond))
+	_, _, err := conn2.ReadMessage()
+	if err == nil {
+		t.Error("conn2 should not receive message for division:1")
+	}
+}
+
+func TestInvalidJSONReturnsError(t *testing.T) {
+	_, s := setupServer(t)
+	conn := dial(t, s)
+	defer conn.Close()
+
+	// Send garbage.
+	conn.WriteMessage(websocket.TextMessage, []byte("{invalid json"))
+
+	ctrl := readJSON[ws.ControlMessage](t, conn)
+	if ctrl.Type != "error" || ctrl.Message != "invalid JSON" {
+		t.Errorf("expected error for invalid JSON, got: %+v", ctrl)
+	}
+}
+
+func TestMissingTopicReturnsError(t *testing.T) {
+	_, s := setupServer(t)
+	conn := dial(t, s)
+	defer conn.Close()
+
+	conn.WriteJSON(ws.InboundMessage{Action: "subscribe", Topic: ""})
+
+	ctrl := readJSON[ws.ControlMessage](t, conn)
+	if ctrl.Type != "error" || ctrl.Message != "topic is required" {
+		t.Errorf("expected 'topic is required' error, got: %+v", ctrl)
+	}
+}
+
+func TestUnknownActionReturnsError(t *testing.T) {
+	_, s := setupServer(t)
+	conn := dial(t, s)
+	defer conn.Close()
+
+	conn.WriteJSON(ws.InboundMessage{Action: "noop", Topic: "readings"})
+
+	ctrl := readJSON[ws.ControlMessage](t, conn)
+	if ctrl.Type != "error" || ctrl.Message != "unknown action: noop" {
+		t.Errorf("expected unknown action error, got: %+v", ctrl)
+	}
+}
+
+func TestDisconnectCleansUpSubscriptions(t *testing.T) {
+	hub, s := setupServer(t)
+	conn := dial(t, s)
+
+	conn.WriteJSON(ws.InboundMessage{Action: "subscribe", Topic: "readings", Room: "division:9"})
+	_ = readJSON[ws.ControlMessage](t, conn) // ack
+
+	time.Sleep(50 * time.Millisecond)
+
+	if got := hub.SubscriberCount("readings", "division:9"); got != 1 {
+		t.Fatalf("expected 1 subscriber, got %d", got)
+	}
+
+	// Close the connection.
+	conn.Close()
+	time.Sleep(100 * time.Millisecond)
+
+	if got := hub.SubscriberCount("readings", "division:9"); got != 0 {
+		t.Errorf("expected 0 subscribers after disconnect, got %d", got)
+	}
+	if got := hub.ClientCount(); got != 0 {
+		t.Errorf("expected 0 clients after disconnect, got %d", got)
+	}
+}


### PR DESCRIPTION
This pull request introduces a new WebSocket infrastructure for the backend, enabling real-time event delivery to clients via both a plain WebSocket API and a minimal Socket.IO-compatible endpoint. The implementation is modular, with clear separation between the WebSocket core, HTTP handlers, and a bridge for relaying Kafka messages. Additionally, comprehensive API documentation is provided.

The most important changes are:

**WebSocket Core Implementation**
* Added a new `ws` package with a thread-safe `Hub` for managing client connections, subscriptions, and message broadcasting (`hub.go`).
* Implemented a `Client` type that manages individual WebSocket connections, supports both plain JSON and Socket.IO protocols, and handles subscribe/unsubscribe actions, message encoding, and connection lifecycle (`client.go`).

**HTTP Integration**
* Added HTTP handlers to upgrade connections to WebSocket, register clients with the hub, and support both `/ws` (plain) and `/socket.io/` (Socket.IO) endpoints (`handler.go`).
* Updated the backend server setup to mount both WebSocket endpoints and compose them with existing REST routes (`main.go`). [[1]](diffhunk://#diff-a5579afae112e85c952ea112934c2952388d30a85ebb7fe8701a82924f64aeabR17) [[2]](diffhunk://#diff-a5579afae112e85c952ea112934c2952388d30a85ebb7fe8701a82924f64aeabR97-R113)

**Kafka Bridge**
* Introduced a `bridge` package with logic to forward Kafka messages to the WebSocket hub, mapping Kafka topics to logical WebSocket topics and constructing room keys as needed (`kafka_ws.go`).

**Documentation**
* Added a detailed API contract and usage documentation for the new WebSocket and Socket.IO endpoints, including protocol, message formats, and testing instructions (`socket-events.md`).