### PR TITLE
docker: add a kafka broker and init script for docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,7 @@
 services:
   ems-backend:
+    depends_on:
+      - kafka-init
     build:
       context: ./backend
     ports:
@@ -14,3 +16,42 @@ services:
       - ems-backend
     ports:
       - "3000:3000"
+
+  broker:
+    image: apache/kafka:4.2.0
+    hostname: broker
+    container_name: broker
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT,CONTROLLER:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://broker:29092,PLAINTEXT_HOST://localhost:9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_NODE_ID: 1
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@broker:29093
+      KAFKA_LISTENERS: PLAINTEXT://broker:29092,CONTROLLER://broker:29093,PLAINTEXT_HOST://0.0.0.0:9092
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_LOG_DIRS: /tmp/kraft-combined-logs
+      CLUSTER_ID: MkU3OEVBNTcwNTJENDM2Qk
+    healthcheck:
+      test: ["CMD-SHELL", "/opt/kafka/bin/kafka-topics.sh --bootstrap-server localhost:9092 --list || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 8
+      start_period: 20s
+
+  kafka-init:
+    image: apache/kafka:4.2.0
+    depends_on:
+      broker:
+        condition: service_healthy
+    volumes:
+      - ./init-kafka.sh:/init-kafka.sh
+    entrypoint: ["/bin/sh", "/init-kafka.sh"]
+    restart: "no"

--- a/init-kafka.sh
+++ b/init-kafka.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+set -e
+
+echo "=== Waiting for Kafka to be ready ==="
+sleep 10
+
+TOPICS="energy.readings energy.anomalies energy.forecasts"
+
+PARTITIONS=1
+REPLICATION_FACTOR=1
+
+echo "=== Deleting previous topic ==="
+for TOPIC in $TOPICS; do
+  echo "Deleting topic: $TOPIC"
+  /opt/kafka/bin/kafka-topics.sh \
+    --bootstrap-server broker:29092 \
+    --delete \
+    --if-exists \
+    --topic "$TOPIC"
+done
+
+echo "=== Creating topics ==="
+for TOPIC in $TOPICS; do
+  echo "Creating topic: $TOPIC"
+  /opt/kafka/bin/kafka-topics.sh \
+    --bootstrap-server broker:29092 \
+    --create \
+    --if-not-exists \
+    --topic "$TOPIC" \
+    --partitions $PARTITIONS \
+    --replication-factor $REPLICATION_FACTOR
+done
+
+echo "=== Listing all topics ==="
+/opt/kafka/bin/kafka-topics.sh \
+  --bootstrap-server broker:29092 \
+  --list
+
+echo "=== Kafka init completed successfully ==="


### PR DESCRIPTION
  This commit adds a kafka broker and a init-kafka script to the docker
  compose.

  The kafka broker will use port 9092 to expose it to the host.
  If the backend is also run in the same docker network use the internal
  29092 port to connect to the broker.