### PR TITLE
feat/add mock kafka producer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-.env
+.env*
 
 .vscode/
 .idea/

--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ From `backend/`:
 go test ./...
 ```
 
+## Run mock kafka producer
+From `backend/`
+
+```bash
+go run cmd/misc/kafka_producer.go
+```
+
 ## API Quick Check
 
 ```bash

--- a/backend/cmd/misc/kafka_producer.go
+++ b/backend/cmd/misc/kafka_producer.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"math/rand"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
+	"github.com/google/uuid"
+	"github.com/joho/godotenv"
+)
+
+type EnergyReading struct {
+	ReadingID   string   `json:"reading_id"`
+	DeviceID    string   `json:"device_id"`
+	DivisionID  string   `json:"division_id"`
+	Timestamp   int64    `json:"timestamp"` // unix millis
+	EnergyKWh   float64  `json:"energy_kwh"`
+	VoltageV    *float64 `json:"voltage_v,omitempty"`
+	CurrentA    *float64 `json:"current_a,omitempty"`
+	PowerFactor *float64 `json:"power_factor,omitempty"`
+	Source      string   `json:"source"`
+}
+
+func randomFloat(min, max float64) float64 {
+	return min + rand.Float64()*(max-min)
+}
+
+func RandomEnergyReading() EnergyReading {
+	v := randomFloat(220, 240)
+	c := randomFloat(5, 100)
+	pf := randomFloat(0.8, 1.0)
+
+	return EnergyReading{
+		ReadingID:   uuid.New().String(),
+		DeviceID:    fmt.Sprintf("DEV-%03d", rand.Intn(10)+1),
+		DivisionID:  []string{"DIV-ENGINEERING", "DIV-OPERATIONS", "DIV-FINANCE"}[rand.Intn(3)],
+		Timestamp:   time.Now().UnixMilli(),
+		EnergyKWh:   randomFloat(0.5, 20.0),
+		VoltageV:    &v,
+		CurrentA:    &c,
+		PowerFactor: &pf,
+		Source:      "METER",
+	}
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+
+	err := godotenv.Load()
+	if err != nil {
+		log.Println("No .env file found, using defaults")
+	}
+
+	bootstrapServers := os.Getenv("BOOTSTRAP_SERVERS")
+	if bootstrapServers == "" {
+		bootstrapServers = "localhost:9092"
+	}
+
+	topic := os.Getenv("TOPIC_NAME")
+	if topic == "" {
+		topic = "energy.readings"
+	}
+
+	p, err := kafka.NewProducer(&kafka.ConfigMap{
+		"bootstrap.servers": bootstrapServers,
+		"client.id":         "go-mock-producer",
+	})
+	if err != nil {
+		log.Fatalf("Failed to create producer: %s\n", err)
+	}
+	defer p.Close()
+
+	sigchan := make(chan os.Signal, 1)
+	signal.Notify(sigchan, syscall.SIGINT, syscall.SIGTERM)
+
+	deliveryChan := make(chan kafka.Event)
+
+	go func() {
+		for e := range deliveryChan {
+			switch ev := e.(type) {
+			case *kafka.Message:
+				if ev.TopicPartition.Error != nil {
+					fmt.Printf("Delivery failed: %v\n", ev.TopicPartition.Error)
+				} else {
+					fmt.Printf("Delivered to %s [%d] @ offset %v\n",
+						*ev.TopicPartition.Topic,
+						ev.TopicPartition.Partition,
+						ev.TopicPartition.Offset)
+				}
+			}
+		}
+	}()
+
+	run := true
+	for run {
+		select {
+		case sig := <-sigchan:
+			fmt.Printf("Caught signal %v, shutting down\n", sig)
+			run = false
+		default:
+			payload := RandomEnergyReading()
+
+			value, err := json.Marshal(payload)
+			if err != nil {
+				fmt.Printf("Marshal error: %v\n", err)
+				continue
+			}
+
+			err = p.Produce(&kafka.Message{
+				TopicPartition: kafka.TopicPartition{
+					Topic:     &topic,
+					Partition: kafka.PartitionAny,
+				},
+				Key:   []byte(payload.DeviceID),
+				Value: value,
+			}, deliveryChan)
+
+			if err != nil {
+				fmt.Printf("Produce error: %v\n", err)
+			}
+
+			time.Sleep(1 * time.Second)
+		}
+	}
+
+	close(deliveryChan)
+	p.Flush(5000)
+}

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -5,5 +5,7 @@ go 1.26.1
 require (
 	github.com/Prypiatos/shared-models v1.0.0
 	github.com/confluentinc/confluent-kafka-go/v2 v2.14.1
+	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
+	github.com/joho/godotenv v1.5.1
 )

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -158,6 +158,8 @@ github.com/in-toto/in-toto-golang v0.5.0 h1:hb8bgwr0M2hGdDsLjkJ3ZqJ8JFLL/tgYdAxF
 github.com/in-toto/in-toto-golang v0.5.0/go.mod h1:/Rq0IZHLV7Ku5gielPT4wPHJfH1GdHMCq8+WPxw8/BE=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/jonboulle/clockwork v0.4.0 h1:p4Cf1aMWXnXAUh8lVfewRBx1zaTSYKrKMF2g3ST4RZ4=
 github.com/jonboulle/clockwork v0.4.0/go.mod h1:xgRqUGwRcjKCO1vbZUEtSLrqKoPSsUpK7fnezOII0kc=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=


### PR DESCRIPTION
This adds a mock kafka producer to test both backend and frontend features until the production kafka stream is provided.
    
For now it only produces the high frequency energy.readings stream. Other topics can be added if requested.