### PR TITLE
Added backend integration test coverage for API, websocket, and messa…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,27 @@ jobs:
         run: go test -race ./...
         continue-on-error: true
 
+      - name: Start Kafka broker
+        run: docker compose up -d broker
+
+      - name: Wait for Kafka broker
+        run: |
+          for i in {1..20}; do
+            if docker compose exec -T broker /opt/kafka/bin/kafka-topics.sh --bootstrap-server localhost:9092 --list >/dev/null 2>&1; then
+              exit 0
+            fi
+            sleep 3
+          done
+          echo "Kafka broker not ready"
+          docker compose logs broker
+          exit 1
+
+      - name: Run integration tests
+        working-directory: backend
+        env:
+          KAFKA_BROKER: localhost:9092
+        run: go test -tags=integration ./internal/integration/...
+
   lint:
     name: Run Linting
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ BINARY_NAME  := ems-backend
 MIGRATIONS_DIR := ./db/postgres/migrations
 DB_URL         := "postgres://user:password@localhost:5432/ems_db?sslmode=disable"
 
-.PHONY: run run-backend run-frontend test test-backend test-frontend \
+.PHONY: run run-backend run-frontend test test-backend test-frontend test-integration \
         build build-backend build-frontend lint lint-backend lint-frontend \
         clean help \
 		db-migrate-postgres db-migrate-down db-migration-create
@@ -28,6 +28,10 @@ test: test-backend test-frontend ## Run all tests
 
 test-backend: ## Run Go tests with race detector
 	cd $(BACKEND_DIR) && go test -race ./...
+
+test-integration: ## Run backend integration tests (Kafka required)
+	docker compose up -d broker
+	cd $(BACKEND_DIR) && KAFKA_BROKER=localhost:9092 go test -tags=integration ./internal/integration/...
 
 test-frontend: ## Run Next.js / Jest tests
 	cd $(FRONTEND_DIR) && npm test --if-present

--- a/README.md
+++ b/README.md
@@ -66,6 +66,15 @@ From `backend/`:
 go test ./...
 ```
 
+## Run Integration Tests
+From repo root (requires Docker and Kafka broker via docker compose):
+
+```bash
+make test-integration
+```
+
+This command brings up the Kafka broker and runs the Go integration tests under `backend/internal/integration`.
+
 ## Run mock kafka producer
 From `backend/`
 

--- a/backend/internal/integration/helpers_test.go
+++ b/backend/internal/integration/helpers_test.go
@@ -1,0 +1,232 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Prypiatos/ems-app/backend/internal/app"
+	"github.com/Prypiatos/ems-app/backend/internal/config"
+	skafka "github.com/segmentio/kafka-go"
+)
+
+const (
+	defaultKafkaBroker = "localhost:9092"
+	startupTimeout     = 10 * time.Second
+	pollInterval       = 150 * time.Millisecond
+)
+
+func TestMain(m *testing.M) {
+	broker := kafkaBroker()
+	if err := waitForBroker(broker, startupTimeout); err != nil {
+		fmt.Fprintf(os.Stderr, "kafka broker not reachable at %s: %v\n", broker, err)
+		os.Exit(1)
+	}
+
+	os.Exit(m.Run())
+}
+
+func kafkaBroker() string {
+	if broker := os.Getenv("KAFKA_BROKER"); broker != "" {
+		return broker
+	}
+	return defaultKafkaBroker
+}
+
+func waitForBroker(broker string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", broker, 300*time.Millisecond)
+		if err == nil {
+			_ = conn.Close()
+			return nil
+		}
+		lastErr = err
+		time.Sleep(200 * time.Millisecond)
+	}
+	if lastErr == nil {
+		lastErr = errors.New("timeout waiting for broker")
+	}
+	return lastErr
+}
+
+func reserveAddr(t *testing.T) string {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := listener.Addr().String()
+	if err := listener.Close(); err != nil {
+		t.Fatalf("close listener: %v", err)
+	}
+	return addr
+}
+
+func startRuntime(t *testing.T) (string, func()) {
+	t.Helper()
+	addr := reserveAddr(t)
+
+	cfg := config.Config{
+		ServerAddr:           addr,
+		Topics:               []string{"telemetry"},
+		TopicGroups:          map[string]string{},
+		TelemetryTopic:       "telemetry",
+		EnableTopicDiscovery: true,
+		HubBufferSize:        64,
+		ClientBufferSize:     16,
+		PublishTimeout:       2 * time.Second,
+		ClientWriteDeadline:  2 * time.Second,
+		ClientReadDeadline:   5 * time.Second,
+		ClientPingInterval:   2 * time.Second,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	rt := app.New(cfg)
+	done := make(chan error, 1)
+	go func() { done <- rt.Run(ctx, cancel) }()
+
+	baseURL := "http://" + addr
+	waitForHTTP(t, baseURL+"/api/v1/health", startupTimeout)
+
+	stop := func() {
+		cancel()
+		waitForShutdown(t, done)
+	}
+
+	return baseURL, stop
+}
+
+func waitForHTTP(t *testing.T, url string, timeout time.Duration) {
+	t.Helper()
+	client := &http.Client{Timeout: 500 * time.Millisecond}
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		resp, err := client.Get(url)
+		if err == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return
+			}
+			lastErr = fmt.Errorf("status %d", resp.StatusCode)
+		} else {
+			lastErr = err
+		}
+		time.Sleep(pollInterval)
+	}
+	if lastErr != nil {
+		t.Fatalf("health endpoint not ready: %v", lastErr)
+	}
+	t.Fatalf("health endpoint not ready")
+}
+
+func waitForShutdown(t *testing.T, done <-chan error) {
+	t.Helper()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("runtime stopped with error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("runtime did not stop")
+	}
+}
+
+func waitForCondition(t *testing.T, timeout time.Duration, fn func() (bool, error)) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		ok, err := fn()
+		if err == nil && ok {
+			return
+		}
+		lastErr = err
+		time.Sleep(pollInterval)
+	}
+	if lastErr != nil {
+		t.Fatalf("condition not met: %v", lastErr)
+	}
+	t.Fatal("condition not met")
+}
+
+func httpGetJSON(url string, target any) error {
+	client := &http.Client{Timeout: 2 * time.Second}
+	resp, err := client.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("status %d", resp.StatusCode)
+	}
+	return json.NewDecoder(resp.Body).Decode(target)
+}
+
+func createKafkaTopic(t *testing.T, broker, topic string) {
+	t.Helper()
+	conn, err := skafka.Dial("tcp", broker)
+	if err != nil {
+		t.Fatalf("dial broker: %v", err)
+	}
+	defer conn.Close()
+
+	err = conn.CreateTopics(skafka.TopicConfig{
+		Topic:             topic,
+		NumPartitions:     1,
+		ReplicationFactor: 1,
+	})
+	if err != nil && !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("create topic %s: %v", topic, err)
+	}
+}
+
+func writeKafkaMessage(t *testing.T, broker, topic string, payload []byte) {
+	t.Helper()
+	writer := &skafka.Writer{
+		Addr:     skafka.TCP(broker),
+		Topic:    topic,
+		Balancer: &skafka.LeastBytes{},
+	}
+	defer writer.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := writer.WriteMessages(ctx, skafka.Message{Value: payload}); err != nil {
+		t.Fatalf("write kafka message: %v", err)
+	}
+}
+
+func mustJSON(t *testing.T, v any) []byte {
+	t.Helper()
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("json marshal: %v", err)
+	}
+	return data
+}
+
+func newNodeID() string {
+	return fmt.Sprintf("node_%d", time.Now().UnixNano())
+}
+
+func containsString(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/integration/http_kafka_test.go
+++ b/backend/internal/integration/http_kafka_test.go
@@ -1,0 +1,119 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/Prypiatos/ems-app/backend/internal/stream"
+)
+
+func TestKafkaUpdatesStateForEventsAndHealth(t *testing.T) {
+	broker := kafkaBroker()
+	nodeID := newNodeID()
+	eventsTopic := fmt.Sprintf("energy.nodes.%s.events", nodeID)
+	healthTopic := fmt.Sprintf("energy.nodes.%s.health", nodeID)
+
+	createKafkaTopic(t, broker, eventsTopic)
+	createKafkaTopic(t, broker, healthTopic)
+
+	baseURL, stop := startRuntime(t)
+	defer stop()
+
+	now := time.Now().UnixMilli()
+	event := stream.Event{
+		NodeID:    nodeID,
+		NodeType:  "smart_meter",
+		Timestamp: now,
+		EventType: "startup",
+		Severity:  "low",
+		Message:   "integration test event",
+		Buffered:  false,
+	}
+	writeKafkaMessage(t, broker, eventsTopic, mustJSON(t, event))
+
+	health := stream.Health{
+		NodeID:        nodeID,
+		NodeType:      "smart_meter",
+		Timestamp:     now,
+		SequenceNo:    1,
+		Status:        "online",
+		UptimeSec:     10,
+		MQTTConnected: true,
+		WiFiConnected: true,
+		SensorOK:      true,
+		BufferedCount: 0,
+	}
+	writeKafkaMessage(t, broker, healthTopic, mustJSON(t, health))
+
+	waitForCondition(t, 10*time.Second, func() (bool, error) {
+		var nodes []string
+		if err := httpGetJSON(baseURL+"/api/v1/nodes", &nodes); err != nil {
+			return false, err
+		}
+		return containsString(nodes, nodeID), nil
+	})
+
+	var events []stream.Event
+	if err := httpGetJSON(baseURL+"/api/v1/nodes/"+nodeID+"/events?limit=1", &events); err != nil {
+		t.Fatalf("get events: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("events len = %d, want 1", len(events))
+	}
+	if events[0].NodeID != nodeID {
+		t.Fatalf("event node_id = %q, want %q", events[0].NodeID, nodeID)
+	}
+
+	var gotHealth stream.Health
+	if err := httpGetJSON(baseURL+"/api/v1/nodes/"+nodeID+"/health", &gotHealth); err != nil {
+		t.Fatalf("get health: %v", err)
+	}
+	if gotHealth.NodeID != nodeID {
+		t.Fatalf("health node_id = %q, want %q", gotHealth.NodeID, nodeID)
+	}
+	if gotHealth.Status != "online" {
+		t.Fatalf("health status = %q, want online", gotHealth.Status)
+	}
+}
+
+func TestKafkaDropsMismatchedEvent(t *testing.T) {
+	broker := kafkaBroker()
+	nodeID := newNodeID()
+	eventsTopic := fmt.Sprintf("energy.nodes.%s.events", nodeID)
+
+	createKafkaTopic(t, broker, eventsTopic)
+
+	baseURL, stop := startRuntime(t)
+	defer stop()
+
+	badEvent := stream.Event{
+		NodeID:    "other_node",
+		NodeType:  "smart_meter",
+		Timestamp: time.Now().UnixMilli(),
+		EventType: "mismatch",
+		Severity:  "high",
+		Message:   "should be ignored",
+		Buffered:  false,
+	}
+	writeKafkaMessage(t, broker, eventsTopic, mustJSON(t, badEvent))
+
+	waitForCondition(t, 10*time.Second, func() (bool, error) {
+		var nodes []string
+		if err := httpGetJSON(baseURL+"/api/v1/nodes", &nodes); err != nil {
+			return false, err
+		}
+		return containsString(nodes, nodeID), nil
+	})
+
+	var events []stream.Event
+	if err := httpGetJSON(baseURL+"/api/v1/nodes/"+nodeID+"/events?limit=5", &events); err != nil {
+		t.Fatalf("get events: %v", err)
+	}
+	if len(events) != 0 {
+		t.Fatalf("events len = %d, want 0", len(events))
+	}
+}

--- a/backend/internal/integration/ws_kafka_test.go
+++ b/backend/internal/integration/ws_kafka_test.go
@@ -1,0 +1,45 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+func TestKafkaTelemetryToWebsocket(t *testing.T) {
+	broker := kafkaBroker()
+	nodeID := newNodeID()
+	telemetryTopic := fmt.Sprintf("energy.nodes.%s.telemetry", nodeID)
+
+	createKafkaTopic(t, broker, telemetryTopic)
+
+	baseURL, stop := startRuntime(t)
+	defer stop()
+
+	wsURL := "ws" + strings.TrimPrefix(baseURL, "http") + "/api/v1/readings"
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("websocket dial: %v", err)
+	}
+	defer conn.Close()
+
+	payload := []byte(fmt.Sprintf("{\"node_id\":\"%s\",\"power_w\":120.5}", nodeID))
+	writeKafkaMessage(t, broker, telemetryTopic, payload)
+
+	if err := conn.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		t.Fatalf("set read deadline: %v", err)
+	}
+	_, msg, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("read websocket message: %v", err)
+	}
+	if string(msg) != string(payload) {
+		t.Fatalf("payload mismatch: got %s want %s", msg, payload)
+	}
+}


### PR DESCRIPTION
This pull request introduces a full integration test suite for the backend, focusing on Kafka integration and end-to-end validation of core backend features. It adds new integration tests, supporting helpers, and updates the CI pipeline, Makefile, and documentation to automate and document these tests.

**Integration Test Infrastructure and Automation**

* Added new backend integration tests under `backend/internal/integration/`, including HTTP and WebSocket tests that validate Kafka message ingestion and correct API/websocket behavior. [[1]](diffhunk://#diff-779ef784cb0bd1003081cd1315089e8df64be8e58143c4e8b00b57c472f9aa34R1-R119) [[2]](diffhunk://#diff-60426d06ac31df8ee1023a5b1268e36302e02048b6769bad7091efc0c50f2675R1-R45)
* Introduced reusable test helpers in `helpers_test.go` to manage Kafka topics/messages, runtime startup, and HTTP/WebSocket assertions for integration testing.

**CI/CD and Developer Workflow Updates**

* Updated `.github/workflows/ci.yml` to start a Kafka broker in CI, wait for readiness, and run the new integration tests automatically.
* Added a `test-integration` target to the `Makefile` to run integration tests locally with Dockerized Kafka, and documented the workflow in `README.md`. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L7-R7) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R32-R35) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R69-R77)